### PR TITLE
Use valid category in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -4,6 +4,6 @@ author=Jordi Guillaumes Pons
 maintainer=https://gogs.jguillaumes.dyndns.org/jguillaumes/SPISRAM
 sentence=Basic support for the 23LCV1024 serial SRAM chip
 paragraph=Basic support for the 23LCV1024 serial SRAM chip
-category=Memory
+category=Data Storage
 url=https://gogs.jguillaumes.dyndns.org/jguillaumes/SPISRAM
 architectures=AVR


### PR DESCRIPTION
The previous category value caused the warning:
```
WARNING: Category 'Memory' in library SPISRAM is not valid. Setting to 'Uncategorized'
```
List of valid category values:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format