### PR TITLE
Correct architectures value in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -6,4 +6,4 @@ sentence=Basic support for the 23LCV1024 serial SRAM chip
 paragraph=Basic support for the 23LCV1024 serial SRAM chip
 category=Data Storage
 url=https://gogs.jguillaumes.dyndns.org/jguillaumes/SPISRAM
-architectures=AVR
+architectures=avr


### PR DESCRIPTION
The previous architectures value caused the Arduino IDE to display a warning when the library is compiled:
```
WARNING: library SPISRAM claims to run on (AVR) architecture(s) and may be incompatible with your current board which runs on (avr) architecture(s).
```
The previous architectures value caused the library's examples to be placed under the File > Examples > INCOMPATIBLE menu.